### PR TITLE
feat:お知らせ機能の追加｡microCMSでnewsから取得

### DIFF
--- a/src/app/(home)/index.tsx
+++ b/src/app/(home)/index.tsx
@@ -5,11 +5,13 @@ import { Article } from '@/src/features/article';
 import { ArticleCard } from '../../features/article/components/ArticleCard';
 import { TodayScheduleList } from '@/src/features/schedule';
 import { useArticles } from '@/src/features/article/hooks/useArticles';
+import { useInformation, InformationModal } from '@/src/features/information';
 import MaskLoading from '@/src/components/MaskLoading';
 import Title from '@/src/components/Title';
 
 export default function Home() {
   const { articles, loading } = useArticles();
+  const { currentInformation, isModalVisible, handleCloseModal } = useInformation();
 
   if (loading) {
     return <MaskLoading />;
@@ -39,6 +41,11 @@ export default function Home() {
           </View>
         </View>
       </ScrollView>
+      <InformationModal
+        information={currentInformation}
+        visible={isModalVisible}
+        onClose={handleCloseModal}
+      />
     </BackgroundView>
   );
 }

--- a/src/features/information/apis/fetchInformationList.ts
+++ b/src/features/information/apis/fetchInformationList.ts
@@ -1,0 +1,28 @@
+import { Information, InformationType } from '@/src/features/information/types/Information';
+import dayjs from 'dayjs';
+
+/**
+ * お知らせ一覧の取得
+ * endAtが今日を過ぎているものは除外する
+ */
+export async function fetchInformationList() {
+  // 今日の日付を取得（YYYY-MM-DD形式）
+  const todayString = dayjs().format('YYYY-MM-DD');
+
+  // microCMSのフィルタ: endAtがnull（未設定）または今日以降のもののみ取得
+  const filters = `endAt[greater_than]${todayString}[or]endAt[not_exists]`;
+  const url = new URL(`${process.env.EXPO_PUBLIC_MICROCMS_URI!}/news`);
+  url.searchParams.append('filters', filters);
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'X-MICROCMS-API-KEY': process.env.EXPO_PUBLIC_MICROCMS_API_KEY! },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch information list');
+  }
+
+  const informationList = await response.json();
+  return informationList.contents.map((content: InformationType) => new Information(content));
+}

--- a/src/features/information/components/InformationModal.tsx
+++ b/src/features/information/components/InformationModal.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { View, Text, Modal, Linking, ScrollView } from 'react-native';
+import { Image } from 'expo-image';
+import { useTheme } from '@/src/contexts/ThemeContext';
+import Button from '@/src/components/Button';
+import { Information } from '../types/Information';
+import { LogUtil } from '@/src/libs/LogUtil';
+
+interface InformationModalProps {
+  information: Information | null;
+  visible: boolean;
+  onClose: () => void;
+}
+
+/**
+ * お知らせモーダルコンポーネント
+ * @param {Information | null} information - 表示するお知らせデータ
+ * @param {boolean} visible - モーダルの表示/非表示
+ * @param {() => void} onClose - モーダルを閉じるコールバック
+ */
+export default function InformationModal({ information, visible, onClose }: InformationModalProps) {
+  const { isDarkMode } = useTheme();
+
+  /**
+   * 詳細ページをブラウザで開く
+   * @param {string} detailUrl - 詳細ページのURL
+   */
+  const handleOpenDetail = async (detailUrl: string): Promise<void> => {
+    try {
+      LogUtil.log('Opening browser for information detail', {
+        level: 'info',
+        additionalInfo: { informationId: information?.id },
+      });
+
+      const supported = await Linking.canOpenURL(detailUrl);
+
+      if (supported) {
+        await Linking.openURL(detailUrl);
+
+        LogUtil.log('Browser opened successfully', {
+          level: 'info',
+          additionalInfo: { informationId: information?.id },
+        });
+      } else {
+        throw new Error('Invalid URL');
+      }
+    } catch (error) {
+      LogUtil.log('Failed to open browser', {
+        level: 'error',
+        additionalInfo: { informationId: information?.id },
+        error: error as Error,
+      });
+
+      // エラーメッセージの統一
+      if (error instanceof Error) {
+        if (error.message.includes('Invalid URL')) {
+          throw new Error('無効なURLです');
+        }
+      }
+
+      throw error;
+    }
+  };
+
+  if (!information) {
+    return null;
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View className="flex-1 bg-black/50 justify-center items-center p-5">
+        <View
+          className={`rounded-xl p-6 w-full max-w-sm ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}
+        >
+          <ScrollView showsVerticalScrollIndicator={false}>
+            {/* 画像 */}
+            {information.image && (
+              <View className="mb-4 w-full">
+                <Image
+                  cachePolicy="memory-disk"
+                  source={{ uri: information.image.url }}
+                  style={{
+                    width: '100%',
+                    height: 200,
+                    resizeMode: 'cover',
+                    borderRadius: 8,
+                  }}
+                />
+              </View>
+            )}
+
+            {/* タイトル */}
+            <Text className={`text-xl font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-black'}`}>
+              {information.title}
+            </Text>
+
+            {/* 本文 */}
+            <Text
+              className={`text-base mb-6 leading-6 ${
+                isDarkMode ? 'text-gray-300' : 'text-gray-600'
+              }`}
+            >
+              {information.body}
+            </Text>
+
+            {/* 詳細はこちらボタン */}
+            {information.detailUrl && (
+              <View className="mb-4">
+                <Button
+                  text="詳細はこちら"
+                  theme="info"
+                  onPress={() => {
+                    if (information.detailUrl) {
+                      handleOpenDetail(information.detailUrl).catch((error) => {
+                        LogUtil.log('Failed to open detail URL', {
+                          level: 'error',
+                          error: error as Error,
+                        });
+                      });
+                    }
+                  }}
+                />
+              </View>
+            )}
+
+            {/* 閉じるボタン */}
+            <Button text="閉じる" theme="background" onPress={onClose} />
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/features/information/hooks/useInformation.ts
+++ b/src/features/information/hooks/useInformation.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Information } from '../types/Information';
+import { fetchInformationList } from '../apis/fetchInformationList';
+import { LogUtil } from '../../../libs/LogUtil';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const INFORMATION_VIEWED_IDS_KEY = '@information_viewed_ids';
+
+/**
+ * お知らせ管理用のカスタムフック
+ */
+export const useInformation = () => {
+  const [informationList, setInformationList] = useState<Information[]>([]);
+  const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  /**
+   * 表示済みお知らせID一覧を取得
+   * @return {Promise<string[]>} 表示済みお知らせIDの配列
+   */
+  const getViewedIdList = async (): Promise<string[]> => {
+    try {
+      const viewedIdsJson = await AsyncStorage.getItem(INFORMATION_VIEWED_IDS_KEY);
+      if (viewedIdsJson) {
+        return JSON.parse(viewedIdsJson) as string[];
+      }
+      return [];
+    } catch (error) {
+      LogUtil.log('Failed to get viewed information IDs', {
+        level: 'error',
+        error: error as Error,
+      });
+      return [];
+    }
+  };
+
+  /**
+   * 表示済みお知らせIDを保存
+   * @param {string[]} viewedIdList - 表示済みお知らせIDの配列
+   */
+  const setViewedIdList = async (viewedIdList: string[]): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(INFORMATION_VIEWED_IDS_KEY, JSON.stringify(viewedIdList));
+    } catch (error) {
+      LogUtil.log('Failed to save viewed information IDs', {
+        level: 'error',
+        error: error as Error,
+      });
+    }
+  };
+
+  /**
+   * 有効期間内のお知らせをフィルタリング
+   * API側でendAtが今日を過ぎているものは既に除外されているため、startAtのみチェック
+   * @param {Information[]} infoList - お知らせ一覧
+   * @return {Information[]} 有効期間内のお知らせ一覧
+   */
+  const filterValidInformations = useCallback((infoList: Information[]): Information[] => {
+    const now = new Date();
+
+    return infoList.filter((info) => {
+      const startAt = new Date(info.startAt);
+
+      // startAtが現在日時以降でない場合は除外
+      if (startAt > now) {
+        return false;
+      }
+
+      return true;
+    });
+  }, []);
+
+  /**
+   * 未表示のお知らせを抽出
+   * @param {Information[]} validInformationList - 有効期間内のお知らせ一覧
+   * @param {string[]} viewedIdList - 表示済みお知らせIDの配列
+   * @return {Information[]} 未表示のお知らせ一覧
+   */
+  const filterUnviewedInformations = useCallback(
+    (validInformationList: Information[], viewedIdList: string[]): Information[] => {
+      return validInformationList.filter((info) => !viewedIdList.includes(info.id));
+    },
+    []
+  );
+
+  /**
+   * お知らせ一覧を取得
+   */
+  const fetchInformations = useCallback(async () => {
+    setLoading(true);
+    try {
+      const infoList = await fetchInformationList();
+
+      // 有効期間内のお知らせをフィルタリング（startAtのみチェック、API側でendAtは既に除外済み）
+      const validInformationList = filterValidInformations(infoList);
+
+      // 表示済みIDを取得
+      const viewedIdList = await getViewedIdList();
+
+      // 未表示のお知らせを抽出
+      const unviewedInformationList = filterUnviewedInformations(
+        validInformationList,
+        viewedIdList
+      );
+
+      setInformationList(unviewedInformationList);
+
+      // 未表示のお知らせがある場合、モーダルを表示
+      if (unviewedInformationList.length > 0) {
+        setCurrentIndex(0);
+        setIsModalVisible(true);
+      }
+    } catch (error) {
+      LogUtil.log('Failed to fetch informations', {
+        level: 'error',
+        error: error as Error,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [filterValidInformations, filterUnviewedInformations]);
+
+  /**
+   * モーダルを閉じる
+   */
+  const handleCloseModal = useCallback(async () => {
+    const currentInfo = informationList[currentIndex];
+    if (currentInfo) {
+      // 表示済みIDを取得して追加
+      const viewedIdList = await getViewedIdList();
+      if (!viewedIdList.includes(currentInfo.id)) {
+        viewedIdList.push(currentInfo.id);
+        await setViewedIdList(viewedIdList);
+      }
+
+      // 次のお知らせがある場合は表示
+      if (currentIndex < informationList.length - 1) {
+        setCurrentIndex(currentIndex + 1);
+      } else {
+        // すべて表示した場合はモーダルを閉じる
+        setIsModalVisible(false);
+        setCurrentIndex(0);
+      }
+    }
+  }, [currentIndex, informationList]);
+
+  /**
+   * 現在表示中のお知らせを取得
+   * @return {Information | null} 現在表示中のお知らせ
+   */
+  const getCurrentInformation = (): Information | null => {
+    if (informationList.length === 0 || currentIndex >= informationList.length) {
+      return null;
+    }
+    return informationList[currentIndex];
+  };
+
+  useEffect(() => {
+    fetchInformations();
+  }, [fetchInformations]);
+
+  return {
+    informationList,
+    currentInformation: getCurrentInformation(),
+    loading,
+    isModalVisible,
+    setIsModalVisible,
+    handleCloseModal,
+    fetchInformations,
+  };
+};
+ 

--- a/src/features/information/index.ts
+++ b/src/features/information/index.ts
@@ -1,0 +1,11 @@
+// 型定義
+export * from './types/Information';
+
+// API
+export { fetchInformationList } from './apis/fetchInformationList';
+
+// コンポーネント
+export { default as InformationModal } from './components/InformationModal';
+
+// フック
+export { useInformation } from './hooks/useInformation';

--- a/src/features/information/types/Information.ts
+++ b/src/features/information/types/Information.ts
@@ -1,0 +1,53 @@
+export type ImageType = {
+  url: string;
+  height: number;
+  width: number;
+};
+
+export type InformationType = {
+  id: string;
+  title: string;
+  body: string;
+  startAt: string;
+  endAt: string | undefined;
+  image: ImageType | undefined;
+  detailUrl: string | undefined;
+};
+
+/**
+ * 画像クラス
+ */
+export class Image {
+  url: string = '';
+  height: number = 0;
+  width: number = 0;
+
+  constructor(data: ImageType) {
+    this.url = data.url;
+    this.height = data.height;
+    this.width = data.width;
+  }
+}
+
+/**
+ * お知らせクラス
+ */
+export class Information {
+  id: string = '';
+  title: string = '';
+  body: string = '';
+  startAt: string = '';
+  endAt: string | undefined;
+  image: Image | undefined;
+  detailUrl: string | undefined;
+
+  constructor(data: InformationType) {
+    this.id = data.id;
+    this.title = data.title;
+    this.body = data.body;
+    this.startAt = data.startAt;
+    this.endAt = data.endAt;
+    this.image = data.image ? new Image(data.image) : undefined;
+    this.detailUrl = data.detailUrl;
+  }
+}

--- a/test/features/schedule/libs/generateShareMessage.spec.ts
+++ b/test/features/schedule/libs/generateShareMessage.spec.ts
@@ -1,50 +1,45 @@
-import {generateShareMessage} from '@/src/features/schedule';
+import { generateShareMessage } from '@/src/features/schedule';
 import { Plan } from '@/src/features/plan';
-import { Schedule } from '@/src/features/schedule/types/Schedule';
 import dayjs from 'dayjs';
 
-
 describe('##### generateShareMessage Test #####', () => {
+  // plan
+  const plan = {
+    uid: 'plan uid',
+    title: 'title text',
+    description: 'description text',
+    memo: 'memo text',
+    schedule: [
+      {
+        title: '移動',
+        description: '移動の説明',
+        category: 'Movement',
+        place_list: [],
+        from: dayjs('2025-01-01 10:00:00').toISOString(),
+        to: dayjs('2025-01-01 13:00:00').toISOString(),
+      },
+      {
+        title: 'カフェ',
+        description: 'カフェの説明',
+        category: 'Cafe',
+        place_list: [
+          {
+            displayName: { text: 'カフェ1', languageCode: 'ja' },
+            googleMapsUri: 'https://maps.google.com/?cid=カフェ１',
+          },
+          {
+            displayName: { text: 'カフェ2', languageCode: 'ja' },
+            googleMapsUri: 'https://maps.google.com/?cid=カフェ２',
+          },
+        ],
+        from: dayjs('2025-01-01 13:00:00').toISOString(),
+        to: dayjs('2025-01-01 14:00:00').toISOString(),
+      },
+    ],
+  };
 
-    // plan
-    const plan = {
-        uid: 'plan uid',
-        title: 'title text',
-        description: 'description text',
-        memo: 'memo text',
-        schedule: [
-            {
-                title: '移動',
-                description: '移動の説明',
-                category: 'Movement',
-                place_list: [],
-                from: dayjs('2025-01-01 10:00:00').toISOString(),
-                to: dayjs('2025-01-01 13:00:00').toISOString(),
-            },
-            {
-                title: 'カフェ',
-                description: 'カフェの説明',
-                category: 'Cafe',
-                place_list: [
-                    {
-                        displayName: {text: 'カフェ1', languageCode: 'ja'},
-                        googleMapsUri: 'https://maps.google.com/?cid=カフェ１',
-                    },
-                    {
-                        displayName: {text: 'カフェ2', languageCode: 'ja'},
-                        googleMapsUri: 'https://maps.google.com/?cid=カフェ２',
-                    }
-
-                ],
-                from: dayjs('2025-01-01 13:00:00').toISOString(),
-                to: dayjs('2025-01-01 14:00:00').toISOString(),
-            }
-        ]
-    };
-
-
-    test('共有メッセージの作成', () => {
-        const expected = `【Re:CoL】title text
+  test('共有メッセージの作成', () => {
+    const expected = `【Re:CoL】title text
 ■■■メモ■■■
 memo text
 
@@ -64,14 +59,11 @@ https://maps.google.com/?cid=カフェ１
 https://maps.google.com/?cid=カフェ２
 ---------------------------------------------
 `;
-        try {
-            
-            const result = generateShareMessage(plan as unknown as Plan);
-            expect(result).toEqual(expected);
-        } catch (e) {
-            fail(e);
-        }
-    });
-
-
+    try {
+      const result = generateShareMessage(plan as unknown as Plan);
+      expect(result).toEqual(expected);
+    } catch (e) {
+      fail(e);
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an information/news feature that fetches from microCMS, shows sequential modals on Home, and tracks viewed items in storage.
> 
> - **Information feature**
>   - **API**: Fetch list from microCMS `news` with `endAt` filter in `fetchInformationList` and map to `Information` models.
>   - **Types/Models**: Introduce `Information`, `Image`, and related types in `features/information/types`.
>   - **Hook**: `useInformation` to load/queue valid items (filters by `startAt`), persist viewed IDs via `AsyncStorage`, and control modal flow.
>   - **UI**: `InformationModal` to display title/body/image, optional detail button opens URL via `Linking`, and close handling; uses theme and `LogUtil`.
>   - **Exports**: Barrel `features/information/index` exposes API, hook, and modal.
> - **Home integration**
>   - Use `useInformation` and render `InformationModal` in `src/app/(home)/index.tsx` to show news on app home.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96cdd8232fd1f2c9fa350568b09378589733c8e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->