### PR TITLE
fix: 文言修正

### DIFF
--- a/src/features/plan/components/PlanCard.tsx
+++ b/src/features/plan/components/PlanCard.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import dayjs from 'dayjs';
 import { Alert, Text, TouchableOpacity, View } from 'react-native';
 import { deletePlan } from '@/src/features/plan';
-
+import i18n from '@/src/libs/i18n';
 export default function PlanCard({ plan }: { plan: Plan }) {
   // === Member ===
   const router = useRouter();
@@ -31,15 +31,15 @@ export default function PlanCard({ plan }: { plan: Plan }) {
   /** プランの削除 */
   const handleDeletePlan = (plan: Plan) => {
     Alert.alert(
-      '削除しますか？',
-      '年間プラン消費量は戻りません。\nそれでも削除してもよろしいですか？',
+      i18n.t('COMPONENT.PLAN.DELETE_CONFIRM').replace('#title#', plan.title || ''),
+      i18n.t('COMPONENT.PLAN.DELETE_CONFIRM_MESSAGE'),
       [
         {
-          text: 'キャンセル',
+          text: i18n.t('COMMON.CANCEL'),
           style: 'cancel',
         },
         {
-          text: '削除',
+          text: i18n.t('COMMON.DELETE'),
           onPress: async () => {
             deletePlan(plan.uid, session)
               .then(() => {
@@ -86,7 +86,7 @@ export default function PlanCard({ plan }: { plan: Plan }) {
               </Text>
             ) : (
               <Text className="text-light-text dark:text-dark-text text-sm line-clamp-2 opacity-70">
-                メモがありません
+                {i18n.t('COMPONENT.PLAN.NO_MEMO')}
               </Text>
             )}
           </View>

--- a/src/features/schedule/components/ScheduleComponent.tsx
+++ b/src/features/schedule/components/ScheduleComponent.tsx
@@ -85,10 +85,11 @@ export default function ScheduleComponents({
   const handleScheduleLongPress = (schedule: Schedule) => {
     if (!onDelete) return;
     // 削除アラート
-    Alert.alert(schedule.title!, 'このスケジュールを削除しますか？', [
-      { text: 'キャンセル', style: 'cancel' },
+    const text = i18n.t('SCREEN.SCHEDULE.DELETE_SUCCESS').replace('#title#', schedule.title || '');
+    Alert.alert(text, i18n.t('SCREEN.SCHEDULE.DELETE_CONFIRM'), [
+      { text: i18n.t('COMMON.CANCEL'), style: 'cancel' },
       {
-        text: '削除',
+        text: i18n.t('COMMON.DELETE'),
         style: 'destructive',
         onPress: () => {
           // 削除処理

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -153,7 +153,8 @@
             "PLAN_NOT_FOUND": "Planinformationen konnten nicht abgerufen werden",
             "FETCH_FAILED": "Planinformationen konnten nicht abgerufen werden",
             "CANDIDATE_COUNT": "#count# Kandidaten gefunden",
-            "DELETE_SUCCESS": "wurde gelöscht",
+            "DELETE_CONFIRM": "Zeitplan löschen",
+            "DELETE_SUCCESS": "#title# wurde gelöscht",
             "SAVE_FAILED": "Zeitplan konnte nicht gespeichert werden",
             "ADD_FROM_MAP": "Von Karte hinzufügen",
             "SELECT_CATEGORY": "Kategorie auswählen",
@@ -201,7 +202,9 @@
             "SORT_SCHEDULE_DATE": "Zeitplandatum (Absteigend)",
             "NO_MEMO": "Keine Notiz.",
             "NO_SCHEDULE_TODAY": "Kein Zeitplan heute",
-            "NO_PLAN_RECENT": "Kein Plan in den letzten #days# Tagen"
+            "NO_PLAN_RECENT": "Kein Plan in den letzten #days# Tagen",
+            "DELETE_CONFIRM": "Plan löschen",
+            "DELETE_CONFIRM_MESSAGE": "Einmal gelöscht, kann nicht wiederhergestellt werden. Sind Sie sicher, dass Sie den Plan löschen möchten?"
         },
         "PAYMENT": {
             "FEATURE": "Funktion",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -153,7 +153,8 @@
             "PLAN_NOT_FOUND": "Could not retrieve plan information",
             "FETCH_FAILED": "Failed to retrieve plan information",
             "CANDIDATE_COUNT": "#count# candidates found",
-            "DELETE_SUCCESS": "has been deleted",
+            "DELETE_CONFIRM": "Are you sure you want to delete this schedule?",
+            "DELETE_SUCCESS": "#title# has been deleted",
             "SAVE_FAILED": "Failed to save schedule",
             "ADD_FROM_MAP": "Add from Map",
             "SELECT_CATEGORY": "Select Category",
@@ -201,7 +202,9 @@
             "SORT_SCHEDULE_DATE": "Schedule Date (Descending)",
             "NO_MEMO": "No memo.",
             "NO_SCHEDULE_TODAY": "No schedule today",
-            "NO_PLAN_RECENT": "No plan recent #days# days"
+            "NO_PLAN_RECENT": "No plan recent #days# days",
+            "DELETE_CONFIRM": "#title# to delete",
+            "DELETE_CONFIRM_MESSAGE": "Once deleted, it cannot be restored. Are you sure you want to delete it?"
         },
         "PAYMENT": {
             "FEATURE": "Feature",

--- a/src/languages/fr.json
+++ b/src/languages/fr.json
@@ -153,7 +153,8 @@
             "PLAN_NOT_FOUND": "Impossible de récupérer les informations du plan",
             "FETCH_FAILED": "Échec de la récupération des informations du plan",
             "CANDIDATE_COUNT": "#count# candidats trouvés",
-            "DELETE_SUCCESS": "a été supprimé",
+            "DELETE_CONFIRM": "Supprimer le calendrier",
+            "DELETE_SUCCESS": "#title# a été supprimé",
             "SAVE_FAILED": "Échec de l'enregistrement du calendrier",
             "ADD_FROM_MAP": "Ajouter depuis la carte",
             "SELECT_CATEGORY": "Sélectionner une catégorie",
@@ -201,7 +202,9 @@
             "SORT_SCHEDULE_DATE": "Date du calendrier (Décroissant)",
             "NO_MEMO": "Aucun mémo.",
             "NO_SCHEDULE_TODAY": "Aucun calendrier aujourd'hui",
-            "NO_PLAN_RECENT": "Aucun plan récent #days# jours"
+            "NO_PLAN_RECENT": "Aucun plan récent #days# jours",
+            "DELETE_CONFIRM": "#title# à supprimer",
+            "DELETE_CONFIRM_MESSAGE": "Une fois supprimé, il ne peut pas être restauré. Êtes-vous sûr de vouloir le supprimer ?"
         },
         "PAYMENT": {
             "FEATURE": "Fonctionnalité",

--- a/src/languages/ja.json
+++ b/src/languages/ja.json
@@ -153,7 +153,8 @@
             "PLAN_NOT_FOUND": "プランの情報が取得できませんでした",
             "FETCH_FAILED": "プランの情報が取得に失敗しました",
             "CANDIDATE_COUNT": "#count# 件候補があります",
-            "DELETE_SUCCESS": "を削除しました",
+            "DELETE_CONFIRM": "スケジュールを削除します",
+            "DELETE_SUCCESS": "#title#を削除しました",
             "SAVE_FAILED": "スケジュールの保存に失敗しました",
             "ADD_FROM_MAP": "マップから確認・追加",
             "SELECT_CATEGORY": "カテゴリを選んでください…",
@@ -201,7 +202,9 @@
             "SORT_SCHEDULE_DATE": "スケジュールの日付順（降順）",
             "NO_MEMO": "メモはありません.",
             "NO_SCHEDULE_TODAY": "本日の予定はありません",
-            "NO_PLAN_RECENT": "直近#days#日のプランはありません"
+            "NO_PLAN_RECENT": "直近#days#日のプランはありません",
+            "DELETE_CONFIRM": "#title#を削除します",
+            "DELETE_CONFIRM_MESSAGE": "一度削除すると復元することはできません。削除してもよろしいですか？"
         },
         "PAYMENT": {
             "FEATURE": "機能",
@@ -257,7 +260,7 @@
         "OK": "OK",
         "SAVE": "保存",
         "NOT_FOUND": "見つかりませんでした",
-        "DELETE": "削除する",
+        "DELETE": "削除",
         "DAYS": " 日",
         "SEARCH": "検索",
         "MONTH": "月"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace hardcoded delete texts with i18n in plan/schedule components and update related de/en/fr/ja translations.
> 
> - **Frontend**:
>   - `PlanCard.tsx`: Localize delete confirmation title/message and buttons; localize "no memo" text; add `i18n` import.
>   - `ScheduleComponent.tsx`: Localize long-press delete alert title/body and buttons.
> - **Translations**:
>   - Update `SCREEN.SCHEDULE` delete strings: `DELETE_CONFIRM`, `DELETE_SUCCESS` in `de/en/fr/ja`.
>   - Add/adjust `COMPONENT.PLAN.DELETE_CONFIRM` and `DELETE_CONFIRM_MESSAGE` in `de/en/fr/ja`.
>   - Tweak `COMMON.DELETE` in `ja`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61e547f673283b8cf957ee4802eaf8c4378e1500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->