### PR TITLE
fix: toast managerは_layoutだけで良かったので修正

### DIFF
--- a/src/app/(home)/(PlanListScreen)/index.tsx
+++ b/src/app/(home)/(PlanListScreen)/index.tsx
@@ -5,7 +5,7 @@ import { useCallback } from 'react';
 import { View } from 'react-native';
 import { usePlan } from '@/src/contexts/PlanContext';
 import { LogUtil } from '@/src/libs/LogUtil';
-import ToastManager, { Toast } from 'toastify-react-native';
+import { Toast } from 'toastify-react-native';
 import { Plan } from '@/src/features/plan/types/Plan';
 import NotFoundPlanView from '../../../features/plan/components/NotFoundPlanView';
 import PlanCard from '../../../features/plan/components/PlanCard';
@@ -85,7 +85,6 @@ export default function PlanListScreen() {
       />
       {/* プランがない場合 */}
       {!planLoading && planList.length === 0 && <NotFoundPlanView />}
-      <ToastManager />
     </BackgroundView>
   );
 }

--- a/src/app/(modal)/PlanCreator.tsx
+++ b/src/app/(modal)/PlanCreator.tsx
@@ -10,7 +10,7 @@ import { ApiErrorResponse } from '@/src/features/commons/apiService';
 import { createPlan } from '@/src/features/plan';
 import { Plan } from '@/src/features/plan/types/Plan';
 import { LogUtil } from '@/src/libs/LogUtil';
-import ToastManager, { Toast } from 'toastify-react-native';
+import { Toast } from 'toastify-react-native';
 import i18n from '@/src/libs/i18n';
 
 export default function PlanCreator() {
@@ -107,7 +107,6 @@ export default function PlanCreator() {
           loading={isLoading}
         />
       </View>
-      <ToastManager />
     </BackgroundView>
   );
 }

--- a/src/app/(modal)/ScheduleTimeEditor.tsx
+++ b/src/app/(modal)/ScheduleTimeEditor.tsx
@@ -15,7 +15,7 @@ import {
   adjustStartAtWhenNormal,
 } from '@/src/features/schedule/libs/scheduleTime';
 import { LogUtil } from '@/src/libs/LogUtil';
-import ToastManager, { Toast } from 'toastify-react-native';
+import { Toast } from 'toastify-react-native';
 import MaskLoading from '@/src/components/MaskLoading';
 import i18n from '@/src/libs/i18n';
 
@@ -193,7 +193,6 @@ export default function ScheduleTimeEditor() {
           />
         </View>
       </BackgroundView>
-      <ToastManager />
     </>
   );
 }

--- a/src/app/(plan)/MapScreen.tsx
+++ b/src/app/(plan)/MapScreen.tsx
@@ -8,7 +8,7 @@ import { Place, Direction, Route, Step } from '@/src/features/map';
 import { DEFAULT_RADIUS } from '@/src/libs/ConstValue';
 import Map from '@/src/features/map/components/Map';
 import { fetchDirection } from '@/src/features/map/libs/direction';
-import ToastManager, { Toast } from 'toastify-react-native';
+import { Toast } from 'toastify-react-native';
 import { NativeEventSubscription } from 'react-native';
 import { Schedule } from '@/src/features/schedule';
 import dayjs from 'dayjs';
@@ -279,7 +279,6 @@ export default function MapScreen() {
         />
       )}
 
-      <ToastManager />
     </>
   );
 }

--- a/src/app/(plan)/ScheduleScreen.tsx
+++ b/src/app/(plan)/ScheduleScreen.tsx
@@ -6,14 +6,13 @@ import { useRouter } from 'expo-router';
 import { Plan, fetchPlan } from '@/src/features/plan';
 import { useFocusEffect } from '@react-navigation/native';
 import { deleteSchedule, Schedule } from '@/src/features/schedule';
-
 import { useAuth } from '@/src/features/auth';
 import { LogUtil } from '@/src/libs/LogUtil';
-import ToastManager, { Toast } from 'toastify-react-native';
-import PlanInformation from '../../features/schedule/components/PlanInformation';
-import ScheduleMenu from '../../features/schedule/components/ScheduleMenu';
 import { ScrollView } from 'react-native-gesture-handler';
 import { BackHandler } from 'react-native';
+import PlanInformation from '../../features/schedule/components/PlanInformation';
+import ScheduleMenu from '../../features/schedule/components/ScheduleMenu';
+import { Toast } from 'toastify-react-native';
 import i18n from '@/src/libs/i18n';
 
 export default function ScheduleScreen(): ReactNode {
@@ -21,7 +20,6 @@ export default function ScheduleScreen(): ReactNode {
   const { plan, setPlan, planLoading } = usePlan();
   const { session } = useAuth();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-
   // === Method ===
   /**
    * 初期表示処理
@@ -72,17 +70,18 @@ export default function ScheduleScreen(): ReactNode {
    * 予定の削除処理
    */
   const handleDeleteSchedule = async (schedule: Schedule) => {
-    deleteSchedule(schedule, session)
-      .then(() => {
-        Toast.success(`${schedule.title} ${i18n.t('SCREEN.SCHEDULE.DELETE_SUCCESS')}`);
-        initView();
-      })
-      .catch((e) => {
-        LogUtil.log(JSON.stringify(e), { level: 'error', notify: true });
-        if (e && e.message) {
-          Toast.warn(e.message);
-        }
-      });
+    const text = i18n.t('SCREEN.SCHEDULE.DELETE_SUCCESS').replace('#title#', schedule.title || '');
+    await deleteSchedule(schedule, session).catch((e) => {
+      LogUtil.log(JSON.stringify(e), { level: 'error', notify: true });
+      if (e && e.message) {
+        Toast.warn(e.message);
+      }
+      throw new Error(e.message);
+    });
+
+    LogUtil.log(text, { level: 'info' });
+    Toast.info(text);
+    initView();
   };
 
   // === Effect ===
@@ -126,7 +125,6 @@ export default function ScheduleScreen(): ReactNode {
           </>
         )}
       </ScrollView>
-      <ToastManager />
     </BackgroundView>
   );
 }

--- a/src/app/(scheduleEditor)/ScheduleEditor.tsx
+++ b/src/app/(scheduleEditor)/ScheduleEditor.tsx
@@ -15,7 +15,7 @@ import { NotificationUtil } from '@/src/libs/NotificationUtil';
 import { LogUtil } from '@/src/libs/LogUtil';
 import { FontAwesome5 } from '@expo/vector-icons';
 import CategorySelector from '../../features/schedule/components/CategorySelector';
-import ToastManager, { Toast } from 'toastify-react-native';
+import { Toast } from 'toastify-react-native';
 import {
   adjustEndAtWhenReversed,
   adjustStartAtWhenNormal,
@@ -120,7 +120,9 @@ export default function ScheduleEditor() {
             />
             {/* 日程 */}
             <View className="w-full flex flex-col justify-start items-start">
-              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>{i18n.t('DATA.SCHEDULE.DATETIME')}</Text>
+              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>
+                {i18n.t('DATA.SCHEDULE.DATETIME')}
+              </Text>
               <View className={`flex flex-row justify-center items-center gap-4`}>
                 <DatePicker
                   mode="datetime"
@@ -172,9 +174,15 @@ export default function ScheduleEditor() {
             />
             {/* マップから追加する */}
             <View className="w-full flex flex-col justify-start items-start gap-4">
-              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>{i18n.t('DATA.SCHEDULE.PLACE_LIST')}</Text>
+              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>
+                {i18n.t('DATA.SCHEDULE.PLACE_LIST')}
+              </Text>
               {/* 追加ボタン */}
-              <Button theme={'info'} onPress={handleMapModal} text={i18n.t('SCREEN.SCHEDULE.ADD_FROM_MAP')} />
+              <Button
+                theme={'info'}
+                onPress={handleMapModal}
+                text={i18n.t('SCREEN.SCHEDULE.ADD_FROM_MAP')}
+              />
 
               {/* 候補数 */}
               <View className="flex flex-row gap-2 items-center">
@@ -192,7 +200,9 @@ export default function ScheduleEditor() {
 
             {/* メモ */}
             <View className="w-full flex flex-col justify-start items-start">
-              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>{i18n.t('DATA.SCHEDULE.MEMO')}</Text>
+              <Text className={`text-lg font-bold text-light-text dark:text-dark-text`}>
+                {i18n.t('DATA.SCHEDULE.MEMO')}
+              </Text>
               <TextInput
                 value={editSchedule.description!}
                 multiline={true}
@@ -221,7 +231,6 @@ export default function ScheduleEditor() {
       </BackgroundView>
       {/* マップモーダル */}
       {openMapModal && <MapModal isOpen={openMapModal} onClose={handleSelectedPlaceList} />}
-      <ToastManager />
     </>
   );
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -24,6 +24,7 @@ import { PremiumPlanProvider } from '../features/auth/hooks/usePremiumPlan';
 import { isUpdateRequired, checkVersion as checkVersionApi } from '../features/version';
 import { ForceUpdateModal } from '../features/version/components/ForceUpdateModal';
 import Constants from 'expo-constants';
+import ToastManager from 'toastify-react-native';
 
 // === LogBox ===
 LogBox.ignoreLogs([
@@ -182,6 +183,7 @@ const RouteLayout = () => {
               <GestureHandlerRootView style={{ flex: 1 }}>
                 <ThemeProvider>
                   <Layout />
+                  <ToastManager />
                 </ThemeProvider>
               </GestureHandlerRootView>
             </LocationProvider>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes ToastManager in _layout and removes all per-screen ToastManager uses; refines schedule deletion toast flow.
> 
> - **Toast handling**:
>   - Add `ToastManager` in `src/app/_layout.tsx` under the app root.
>   - Remove `ToastManager` imports/usages from:
>     - `src/app/(home)/(PlanListScreen)/index.tsx`
>     - `src/app/(modal)/PlanCreator.tsx`
>     - `src/app/(modal)/ScheduleTimeEditor.tsx`
>     - `src/app/(plan)/MapScreen.tsx`
>     - `src/app/(plan)/ScheduleScreen.tsx`
>     - `src/app/(scheduleEditor)/ScheduleEditor.tsx`
> - **Schedule**:
>   - Update `handleDeleteSchedule` in `ScheduleScreen.tsx` to use async/await, log info, and show `Toast.info` with templated success text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aab57028d2cc14abb96638c3c175e775d4f0196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->